### PR TITLE
Informações sobre proventos.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ package-lock.json
 .vscode
 .nyc_output
 coverage
+.env

--- a/README.md
+++ b/README.md
@@ -19,11 +19,15 @@ Crie uma instância do `CeiCrawler` passando os parametros necessários e invoqu
 
 ```javascript
 let ceiCrawler = new CeiCrawler('username', 'password', {/* options */});
-let stockHistory = await ceiCrawler.getStockHistory(startDate, endDate); // Se nenhuma data for passada, irá trazer o histórico inteiro
 ```
 
-Um exemplo de retorno do método acima é:
-
+### Métodos disponíveis
+#### getStockHistory
+Método que processa o histórico de compra e venda de ações. O retorno será um uma lista com todas operações de compra ou venda efetuadas dentro do período informado, se nenhuma data for passada o método retornará todo o histórico disponível.
+```javascript
+let stockHistory = await ceiCrawler.getStockHistory(startDate, endDate);
+```
+Resultado:
 ```javascript
 [
     {
@@ -46,8 +50,40 @@ Um exemplo de retorno do método acima é:
     }
 ]
 ```
+#### getStockHistory
+Método que processa todos os dados disponíveis sobre proventos recebidos em um período e retorna como uma lista. Usualmente os proventos disponíveis na página do CEI são os creditados no mês atual e os já anunciados pela empresas com e sem data definida. Registros com date igual a 2001-01-01 são de proventos anunciados mas sem data definida de pagamento.
+```javascript
+let dividends = await ceiCrawler.getDividends();
+```
+Resultado:
+```javascript
+[
+    [
+  {
+    stockType: 'ON NM',
+    code: 'EGIE3',
+    date: 2001-01-01T02:00:00.000Z,     
+    type: 'JUROS SOBRE CAPITAL PRÓPRIO',
+    quantity: 70,
+    factor: 1,
+    grossValue: 30.03,
+    netValue: 20.58
+  },
+  {
+    stockType: 'PN EDJ N1',
+    code: 'ITSA4',
+    date: 2020-04-01T03:00:00.000Z,
+    type: 'DIVIDENDO',
+    quantity: 450,
+    factor: 1,
+    grossValue: 9.9,
+    netValue: 9.9
+  }
+]
+```
 
-## Options
+
+## Opções
 Na criação de um `CeiCrawler` é possivel especificar alguns valores para o parâmetro `options` que modificam a forma que o crawler funciona. As opções são:
 
 | Propriedade         | Tipo      | Default | Descrição                                                                                                                                                                        |

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "devDependencies": {
     "ava": "^2.4.0",
     "coveralls": "^3.0.9",
-    "nyc": "^15.0.0"
+    "nyc": "^15.0.0",
+    "dotenv": "^8.2.0"
   }
 }

--- a/src/lib/CeiCrawler.js
+++ b/src/lib/CeiCrawler.js
@@ -1,5 +1,6 @@
 const puppeteer = require('puppeteer');
 const StockHistoryCrawler = require('./StockHistoryCrawler');
+const DividendsCrawler = require('./DividendsCrawler');
 const typedefs = require("./typedefs");
 const PuppeteerUtils = require('./PuppeteerUtils');
 
@@ -84,6 +85,14 @@ class CeiCrawler {
     async getStockHistory(startDate, endDate) {
         await this._login();
         return await StockHistoryCrawler.getStockHistory(this._page, this.options, startDate, endDate);
+    }
+
+    /**
+     * @returns {typedefs.DividendData} - List of available Dividends information
+     */
+    async getDividends() {
+        await this._login();
+        return await DividendsCrawler.getDividends(this._page);
     }
 
 }

--- a/src/lib/DividendsCrawler.js
+++ b/src/lib/DividendsCrawler.js
@@ -1,0 +1,65 @@
+const typedefs = require("./typedefs");
+
+const PAGE = {
+    URL: 'https://cei.b3.com.br/CEI_Responsivo/ConsultarProventos.aspx',
+    SEARCH_BUTTON: '#ctl00_ContentPlaceHolder1_btnConsultar',
+    SEARCH_WAITFOR: "#ctl00_ContentPlaceHolder1_lblAtualizadoEm",
+    TABLE_CLASS_NAME: 'responsive',
+}
+
+const DIVIDENDS_TABLE_HEADERS = [
+    {prop: 'stock', type: 'string'},
+    {prop: 'stockType', type: 'string'},
+    {prop: 'code', type: 'string'},
+    {prop: 'date', type: 'date'},
+    {prop: 'type', type: 'string'},
+    {prop: 'quantity', type: 'int'},
+    {prop: 'factor', type: 'int'},
+    {prop: 'grossValue', type: 'float'},
+    {prop: 'netValue', type: 'float'}
+];
+
+class DividendsCrawler {
+
+    /**
+     * Gets dividends data available on CEI page.
+     * @param {puppeteer.Page} page - Logged page to work with
+     * @returns {typedefs.DividendData} - List of available Dividends information
+     */
+    static async getDividends(page) {
+        await page.goto(PAGE.URL);
+        await page.click(PAGE.SEARCH_BUTTON);
+        await page.waitFor(PAGE.SEARCH_WAITFOR);
+
+         /* istanbul ignore next */
+        const dividendsData = await page.evaluate((selector, headers) => {
+            let rows = [];
+            const dividendsTables = Array.from(document.getElementsByClassName(selector));
+
+            // Helper function
+            const parseValue = (value, type) => {
+                if (type === 'string') return value;
+                if (type === 'int')    return parseInt(value.replace('.', ''));
+                if (type === 'float')  return parseFloat(value.replace('.', '').replace(',', '.'));
+                if (type === 'date')   return new Date(value.split('/').reverse()).getTime();
+            }
+            
+            // If there are multiple institutions, there will be a table for each one. 
+            for (const table of dividendsTables) {
+                const data = Array.from(table.rows).slice(1, table.rows.length -1)
+                                    .map(row => Array.from(row.cells).reduce((p, c, i) => {
+                                        p[headers[i].prop] = parseValue(c.innerText, headers[i].type)
+                                        return p;
+                                    }));
+
+                rows = rows.concat(data);
+            }
+
+            return rows;
+        }, PAGE.TABLE_CLASS_NAME, DIVIDENDS_TABLE_HEADERS);
+
+        return dividendsData.map(d => ({...d, date: new Date(d.date)}));
+    }
+}
+
+module.exports = DividendsCrawler;

--- a/src/lib/typedefs.js
+++ b/src/lib/typedefs.js
@@ -36,4 +36,16 @@ const puppeteer = require('puppeteer');
   * @memberof typdefs
   */
 
+  /**
+   * @typedef DividendData
+   * @property {String} stockType - Type of Stock (ON, PN, CI)
+   * @property {String} code - The code of the stock
+   * @property {Date} date - Dividend payment date (can be a future date for scheduled payment)
+   * @property {String} type - Dividend type (Rendimento, JPC, Dividendo)
+   * @property {Number} quantity - Quantity of stock dividend is based
+   * @property {Number} factor - Multiply factor for each stock unit
+   * @property {Number} grossValue - Dividend value before taxes
+   * @property {Number} netValue - Dividend value after taxes 
+   * @memberof typdefs
+   */
 exports.unused = {};

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -3,6 +3,10 @@ const CeiCrawler = require('../src/app')
 const fs = require('fs')
 const typedefs = require("../src/lib/typedefs");
 
+const dotenv = require('dotenv');
+
+dotenv.config();
+
 test.before(t => {
     if (!process.env.CEI_USERNAME || !process.env.CEI_PASSWORD) {
         throw Error('You should set environment variables CEI_USERNAME and CEI_PASSWORD in order to run tests');
@@ -62,6 +66,11 @@ test.serial('stock-history-invalid-dates', async t => {
 
 test.serial('stock-history-invalid-dates-with-cap-on', async t => {
     const result = await t.context.ceiCrawlerCap.getStockHistory(new Date(0), new Date(10000));
+    t.true(result.length > 0);
+});
+
+test.serial('dividends', async t => {
+    const result = await t.context.ceiCrawler.getDividends();
     t.true(result.length > 0);
 });
 


### PR DESCRIPTION
Implementação do método que pega as informações sobre proventos.
Apesar da página de proventos ter um filtro de data ele não é muito útil, por isso não implementei a opção de passar a data para o Crawler. Normalmente os dados exibidos nessa página são os proventos do mês e os que já foram anunciados pelas empresas.

Infelizmente a página não disponibiliza o histórico de proventos.

Alterei a documentação incluindo o novo método e adicionei um pouco mais de descrição da funcionalidade de cada método.

Adicionei uma dependência de desenvolvimento para carregar as variáveis de ambientes de um arquivo de configuração, achei que facilita na hora de testar. Posso remover se não fizer sentido.