### PR TITLE
Suporte para desdobramento de ações

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ Resultado:
 
 #### getDividends(_date_)
 Método que processa todos os dados disponíveis sobre proventos recebidos em um período e retorna como uma lista. Usualmente os proventos disponíveis na página do CEI são os creditados no mês atual e os já anunciados pela empresas com e sem data definida. Registros com date igual `null` são de proventos anunciados mas sem data definida de pagamento.
+
+Além disso, caso existam eventos de desdobramento de ações, eles serão retornados em uma propriedade específica.
 ```javascript
 let dividends = await ceiCrawler.getDividends(date);
 ```
@@ -281,7 +283,22 @@ Resultado:
         "grossValue": 78,
         "netValue": 78
       }
-    ]
+    ],
+    "splitEvents": [
+      {
+        "stock": "B3",
+        "stockType": "ON NM",
+        "code": "B3SA3",
+        "type": "DESDOBRAMENTO DE AÇÕES",
+        "date": "2021-05-18T03:00:00.000Z",
+        "baseQuantity": 49,
+        "factor": 1,
+        "destinationCode": "B3SA3",
+        "quantity": 98,
+        "eventValue": 200,
+        "exerciseValue": 0
+      }
+      ]
   }
 ]
 ```


### PR DESCRIPTION
Esse PR tem o objetivo de resolver o issue #48.

Alterei o método `getDividends()` para poder retornar um novo bloco de informações do split, com o formato abaixo:
```
"splitEvents": [
    {
        "stock": "B3",
        "stockType": "ON NM",
        "code": "B3SA3",
        "type": "DESDOBRAMENTO DE AÇÕES",
        "date": "2021-05-18T03:00:00.000Z",
        "baseQuantity": 49,
        "factor": 1,
        "destinationCode": "B3SA3",
        "quantity": 98,
        "eventValue": 200,
        "exerciseValue": 0
    }
  ]
```

Tive um pouco de dificuldade para testar pois os eventos de desdobramento são raros (eu pessoalmente tive uns 3 ou 4 em um período de 3 anos). Para fazer o teste eu aproveitei que tive um evento recente em uma das minhas posições.

Uma coisa que fiquei pensando é que poderia ser possível fazer testes com base em um HTML contendo as informações. Dessa forma seria possível separar o parsing do crawling. Eu salvei o HTML do meu CEI, caso precisem eu posso compartilhar o exemplo.